### PR TITLE
README.md - Now with Tinfoil! (prevent esoteric htmlspecialchars() bypasses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ $token = $csrf->getToken();
 <?php
 
 if (!empty($_POST['my_name'])) {
-    printf("  <p>Hello <strong>%s!</strong></p>" . PHP_EOL, htmlspecialchars($_POST['my_name'], ENT_QUOTES | ENT_HTML5));
+    printf("  <p>Hello <strong>%s!</strong></p>" . PHP_EOL, htmlspecialchars($_POST['my_name'], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
 }
 
 ?>
-  <form method="POST" action="<?=htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES | ENT_HTML5)?>"><div>
-   <input type="hidden" name="csrf_token" value="<?=htmlspecialchars($token, ENT_QUOTES | ENT_HTML5)?>" />
+  <form method="POST" action="<?=htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES | ENT_HTML5, 'UTF-8')?>"><div>
+   <input type="hidden" name="csrf_token" value="<?=htmlspecialchars($token, ENT_QUOTES | ENT_HTML5, 'UTF-8')?>" />
    What is your name?
    <input type="text" name="my_name" />
    <input type="submit" />

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ $token = $csrf->getToken();
 <?php
 
 if (!empty($_POST['my_name'])) {
-    printf("  <p>Hello <strong>%s!</strong></p>" . PHP_EOL, htmlspecialchars($_POST['my_name']));
+    printf("  <p>Hello <strong>%s!</strong></p>" . PHP_EOL, htmlspecialchars($_POST['my_name'], ENT_QUOTES | ENT_HTML5));
 }
 
 ?>
-  <form method="POST" action="<?=htmlspecialchars($_SERVER['PHP_SELF'])?>"><div>
-   <input type="hidden" name="csrf_token" value="<?=htmlspecialchars($token)?>" />
+  <form method="POST" action="<?=htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES | ENT_HTML5)?>"><div>
+   <input type="hidden" name="csrf_token" value="<?=htmlspecialchars($token, ENT_QUOTES | ENT_HTML5)?>" />
    What is your name?
    <input type="text" name="my_name" />
    <input type="submit" />


### PR DESCRIPTION
Add `ENT_QUOTES` flag to `htmlspecialchars()` in the readme examples to prevent attribute escapes.
